### PR TITLE
查询参数先弄成单值映射，后面再改多值映射

### DIFF
--- a/app.py
+++ b/app.py
@@ -68,13 +68,13 @@ def request(request):
 @sub.get("/request2")
 def request2(request: Request):
     """验证 Headers 是否正常"""
-    return JSONResponse(dict(headers=request.headers.dump()))
+    return JSONResponse(request.headers)
 
 
 @sub.get("/request3")
 def request3(request: Request):
     """验证查询参数是否正常解析"""
-    return PlainTextResponse(str(request.query_params))
+    return JSONResponse(request.query_params)
 
 
 app = Years()

--- a/years/datastructers.py
+++ b/years/datastructers.py
@@ -1,4 +1,5 @@
 from collections.abc import Mapping
+from urllib.parse import parse_qsl
 
 
 class Hearders(Mapping):
@@ -20,3 +21,22 @@ class Hearders(Mapping):
 
     def dump(self):
         return dict(self)
+
+
+class QueryParams(Mapping):
+    """查询参数先弄成只接受一个参数的，后面再弄多值映射"""
+
+    def __init__(self, query_params: str):
+        d = dict(parse_qsl(query_params))
+        self._query_params = {
+            key.decode("latin-1"): value.decode("latin-1") for key, value in d.items()
+        }
+
+    def __getitem__(self, key):
+        return self._query_params[key]
+
+    def __len__(self):
+        return len(self._query_params)
+
+    def __iter__(self):
+        return iter(self._query_params)

--- a/years/requests.py
+++ b/years/requests.py
@@ -1,6 +1,5 @@
 from collections.abc import Mapping
-from urllib.parse import parse_qs
-from years.datastructers import Hearders
+from years.datastructers import Hearders, QueryParams
 
 
 class Request(Mapping):
@@ -24,7 +23,7 @@ class Request(Mapping):
     @property
     def query_params(self):
         if not hasattr(self, "_query_params"):
-            self._query_params = parse_qs(self._scope["query_string"])
+            self._query_params = QueryParams(self._scope["query_string"])
         return self._query_params
 
     @property

--- a/years/responses.py
+++ b/years/responses.py
@@ -38,7 +38,7 @@ class JSONResponse(Response):
     media_type = "application/json"
 
     async def __call__(self, scope, send):
-        self.content = json.dumps(self.content)
+        self.content = json.dumps(dict(self.content))
         return await super().__call__(scope, send)
 
 


### PR DESCRIPTION
1、查询参数先弄成单值映射，后面再改多值映射
2、在返回 json 响应时，强制将 content 转换成 dict，不然用户传入一个自定义映射类型时，还需要手动转换下 eg: return JSONResponse(dict(request.headers))
update: return JSONResponset(request.headers)