### PR TITLE
实现 lifespan 会话管理

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,5 @@
 import asyncio
+from contextlib import asynccontextmanager
 from years.responses import (
     HTMLResponse,
     PlainTextResponse,
@@ -92,11 +93,19 @@ async def debug(request: Request):
     result = 1 / 0
     return PlainTextResponse(result)
 
+
 app = Years()
 
 app.mount("/sub/{name}", sub)
-
 app.debug = True
+
+
+@app.lifespan()
+@asynccontextmanager
+async def lifespan_event():
+    print("收到 startup 事件，数据库启动...")
+    yield
+    print("收到 shutdown 事件，清理工作开始...")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
备注：
    当前只支持给主 App 设置生命周期事件，因为这是服务器启动时的一系列初始化动作，
应当是独立于各 APP 的，但是每个 APP 可能需要自己的 lifespan，而当前的 Lifespan 是服务器的 Lifespan。