### PR TITLE
实现背景任务调度，在响应客户端后的执行的一系列任务；生命周期事件取消使用装饰器实现

### DIFF
--- a/years/background.py
+++ b/years/background.py
@@ -1,0 +1,20 @@
+import typing
+import asyncio
+
+
+class BackgroundTask:
+    def __init__(self, func: typing.Callable = None, *args, **kwargs):
+        self.tasks = []
+        if func is not None:
+            self.tasks.append((func, args, kwargs))
+
+    def add_task(self, func: typing.Callable, *args, **kwargs):
+        self.tasks.append((func, args, kwargs))
+
+    async def __call__(self):
+        for task in self.tasks:
+            func, args, kwargs = task
+            if asyncio.iscoroutinefunction(func):
+                await func(*args, **kwargs)
+            else:
+                await asyncio.to_thread(func, *args, **kwargs)

--- a/years/debug.py
+++ b/years/debug.py
@@ -12,8 +12,6 @@ class DebugMiddleware:
         try:
             await self.endpoint(scope, receive, send)
         except Exception:
-            # 当出现异常的时候，根本没法到原来 return 的地方，原来的路直接断掉了
-            # 所以只能在这里将响应 send 出去了
             err_stack = traceback.format_exc()
             response = PlainTextResponse(err_stack)
             await response(scope, send)


### PR DESCRIPTION
装饰器存在一个问题：当把当前的函数注册成为 lifespane 后，其他的视图函数就不能注册了，这个必须要注册成最后一个 如果后续还使用装饰器的话，这个问题得解决下