### PR TITLE
对 Web 框架增加单元测试，增加对 Request 模型的参数测试；增加 Request 对象的 body 方法

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+pythonpath = .
+testpaths = test

--- a/test/test_requests.py
+++ b/test/test_requests.py
@@ -1,0 +1,76 @@
+import pytest
+
+from years import Request, JSONResponse
+from years.testclient import TestClient
+
+
+@pytest.mark.asyncio
+async def test_request_url():
+    async def app(scope, receive, send):
+        request = Request(scope, receive)
+        data = {"method": request.method, "url": str(request.url)}
+        response = JSONResponse(data)
+        await response(scope, receive, send)
+
+    async with TestClient(app) as client:
+        response = await client.get("/123?a=abc")
+        assert response.json() == {
+            "method": "GET",
+            "url": "http://testserver/123?a=abc",
+        }
+
+        response = await client.get("https://example.org:123/")
+        assert response.json() == {"method": "GET", "url": "https://example.org:123/"}
+
+
+@pytest.mark.asyncio
+async def test_request_query_params():
+    async def app(scope, receive, send):
+        request = Request(scope, receive)
+        params = dict(request.query_params)
+        response = JSONResponse({"params": params})
+        await response(scope, receive, send)
+
+    async with TestClient(app) as client:
+        response = await client.get("/?a=123&b=456")
+        assert response.json() == {"params": {"a": "123", "b": "456"}}
+
+
+@pytest.mark.asyncio
+async def test_request_headers():
+    async def app(scope, receive, send):
+        request = Request(scope, receive)
+        response = JSONResponse({"headers": dict(request.headers)})
+        await response(scope, receive, send)
+
+    async with TestClient(app) as client:
+        response = await client.get("/", headers={"host": "example.org"})
+        assert response.json() == {
+            "headers": {
+                "accept": "*/*",
+                "accept-encoding": "gzip, deflate",
+                "connection": "keep-alive",
+                "user-agent": "python-httpx/0.28.1",
+                "host": "example.org",
+            }
+        }
+
+
+@pytest.mark.asyncio
+async def test_request_body():
+    async def app(scope, receive, send):
+        request = Request(scope, receive)
+        body = await request.body()
+        response = JSONResponse({"body": body.decode()})
+        await response(scope, receive, send)
+
+    client = TestClient(app)
+
+    response = await client.get("/")
+    assert response.json() == {"body": ""}
+
+    response = await client.post("/", json={"a": "123"})
+    assert response.json() == {"body": '{"a":"123"}'}
+
+    response = await client.post("/", content="abc")
+    assert response.json() == {"body": "abc"}

--- a/years/__init__.py
+++ b/years/__init__.py
@@ -1,5 +1,14 @@
 from years.applications import Years
 from years.routing import Mount
+from years.requests import Request
+from years.responses import Response, PlainTextResponse, JSONResponse
 
 
-__all__ = ["Mount", "Years"]
+__all__ = [
+    "Mount",
+    "Years",
+    "Request",
+    "Response",
+    "PlainTextResponse",
+    "JSONResponse",
+]

--- a/years/datastructers.py
+++ b/years/datastructers.py
@@ -9,9 +9,19 @@ class URL:
             host, port = scope["server"]
             scheme = scope["scheme"]
             path = unquote(scope["raw_path"])
-            url = f"{scheme}://{host}:{port}{path}"
+            query_string = scope["query_string"].decode("utf-8")
+            if port is not None:
+                url = f"{scheme}://{host}:{port}{path}"
+            else:
+                url = f"{scheme}://{host}{path}"
+
+            if query_string:
+                url += "?" + query_string
 
         self._url = url
+
+    def __str__(self):
+        return self._url
 
     @property
     def components(self):

--- a/years/requests.py
+++ b/years/requests.py
@@ -54,3 +54,11 @@ class Request(Mapping):
             yield current["body"]
             if not current["more_body"]:
                 break
+
+    async def body(self) -> bytes:
+        if not hasattr(self, "_body"):
+            self._body = b""
+            async for chunk in self.stream():
+                self._body += chunk
+
+        return self._body

--- a/years/responses.py
+++ b/years/responses.py
@@ -19,7 +19,7 @@ class Response:
             self.media_type = media_type
         self.background_task = background_task
 
-    async def __call__(self, scope, send):
+    async def __call__(self, scope, receive, send):
         await send(
             {
                 "type": "http.response.start",
@@ -46,9 +46,9 @@ class PlainTextResponse(Response):
 class JSONResponse(Response):
     media_type = "application/json"
 
-    async def __call__(self, scope, send):
+    async def __call__(self, scope, receive, send):
         self.content = json.dumps(dict(self.content), ensure_ascii=False)
-        return await super().__call__(scope, send)
+        return await super().__call__(scope, receive, send)
 
 
 class StreamingResponse(Response):
@@ -61,7 +61,7 @@ class StreamingResponse(Response):
             self.media_type = media_type
         self.background_task = background_task
 
-    async def __call__(self, scope, send):
+    async def __call__(self, scope, receive, send):
         await send(
             {
                 "type": "http.response.start",
@@ -106,7 +106,7 @@ class FileResponse(Response):
             self.filename = filename
         self.background_task = background_task
 
-    async def __call__(self, scope, send):
+    async def __call__(self, scope, receive, send):
         async with aiofiles.open(self.path, mode="rb") as fp:
             content = await fp.read()
 

--- a/years/testclient.py
+++ b/years/testclient.py
@@ -1,0 +1,7 @@
+import httpx
+
+
+def TestClient(app, base_url: str = "http://testserver"):
+    transport = httpx.ASGITransport(app=app)
+    params = dict(transport=transport, base_url=base_url)
+    return httpx.AsyncClient(**params)


### PR DESCRIPTION
* Bug修复：
    * 修复当 URL 端口号不存在时，解析出来的路径包含 None 的问题
    * Response 响应系列的参数增加 receive 参数